### PR TITLE
fix build for kernel >= 6.3.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -394,8 +394,10 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 		goto exit;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 2)
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
-#else
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
 	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+#else
+	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0, 0);
 #endif
 
 #else


### PR DESCRIPTION
This should fix build for kernel >= 6.3.0

ref:
https://github.com/torvalds/linux/commit/b345f0637c0042f9e6b78378a32256d90f485774